### PR TITLE
Added errors and warnings on invalld sink IDs, sink size overruns

### DIFF
--- a/src/data_sink.c
+++ b/src/data_sink.c
@@ -25,6 +25,9 @@ int main(int argc, char *argv[]) {
     if (params.verbose) {
         dumpCL(stderr, "", &params);
     }
+    if (params.id < 0) {
+        errx(EXIT_INVALID_ID, "sink ID %ld invalid", params.id);
+    }
     if ((fp = fopen(params.sink_file, "rb+")) == NULL) {
         err(EXIT_OPEN_ERR, "can not open '%s'", params.sink_file);
     }
@@ -38,6 +41,10 @@ int main(int argc, char *argv[]) {
     if (params.verbose) {
         show_meta_data(&meta_data);
     }
+    if (params.id >= meta_data.nr_sinks) {
+        errx(EXIT_INVALID_ID, "sink ID %ld > %ld",
+                params.id, meta_data.nr_sinks - 1);
+    }
     seek_data(fp, &meta_data, params.id);
     for (;;) {
         int count = fread(buffer, sizeof(char), BUFF_SIZE, stdin);
@@ -50,6 +57,8 @@ int main(int argc, char *argv[]) {
         } else if (!is_overrun) {
             is_overrun = TRUE;
             fwrite(buffer, sizeof(char), size - meta_data.sink_size, fp);
+            warnx("data written to sink %ld exceeds sink size, data loss\n",
+                    params.id); 
         }
     }
     fseek(fp, (3 + params.id)*sizeof(long), SEEK_SET);

--- a/src/sink_utils.h
+++ b/src/sink_utils.h
@@ -12,6 +12,7 @@
 #define EXIT_SIZE_ERR 7
 #define EXIT_DD_ERR 8
 #define EXIT_MEM_ERR 9
+#define EXIT_INVALID_ID 10
 
 typedef struct {
     long meta_size;


### PR DESCRIPTION
An error is generated when an invalid sink ID is specified (ID < 0 or ID >= nr_sinks), a warning is generated if a sink overrun occurs. Fixes #4 
