### PR TITLE
Feature/report overruns

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -g -O2
 CPPFLAGS =
 LDFLAGS =
-LIBS =
+LIBS = -lm
 INSTALL_DIR = ../bin/
 
 CREATE_OBJS = create_cl_params.o create_cl_params_aux.o sink_utils.o \

--- a/src/info_sink.c
+++ b/src/info_sink.c
@@ -1,15 +1,19 @@
 #include <err.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #include "sink_utils.h"
 #include "info_cl_params.h"
 
+int compute_field_width(long nr_sinks);
+
 int main(int argc, char *argv[]) {
     Params params;
     Meta_data meta_data;
     FILE *fp;
-    long id, data_size, nr_unused = 0;
+    long id, data_size, nr_unused = 0, nr_overrun = 0;
+    int field_width;
     initCL(&params);
     parseCL(&params, &argc, &argv);
     if (params.verbose) {
@@ -22,19 +26,34 @@ int main(int argc, char *argv[]) {
     printf("meta size = %ld byte\n", meta_data.meta_size);
     printf("sink size = %ld byte\n", meta_data.sink_size);
     printf("number of sinks = %ld\n", meta_data.nr_sinks);
+    field_width = compute_field_width(meta_data.nr_sinks);
     for (id = 0; id < meta_data.nr_sinks; id++) {
         data_size = read_data_size(fp, id);
         if (data_size >= 0) {
-            printf("size id %ld = %ld byte\n", id, data_size);
+            printf("size id %5ld = %ld byte", id, data_size);
+            if (data_size > meta_data.sink_size) {
+                nr_overrun++;
+                printf(" > %ld, %ld byte lost", meta_data.sink_size,
+                       data_size - meta_data.sink_size);
+            }
+            printf("\n");
         } else {
-            printf("size id %ld unused\n", id);
+            printf("size id %5ld unused\n", id);
             nr_unused++;
         }
     }
     if (nr_unused > 0) {
         fprintf(stderr, "### warning: %ld sinks were unused\n", nr_unused);
     }
+    if (nr_overrun > 0) {
+        fprintf(stderr, "### error: %ld sinks lost data,\n", nr_overrun);
+        fprintf(stderr, "#          snik ize too small\n");
+    }
     fclose(fp);
     finalizeCL(&params);
     return EXIT_SUCCESS;
+}
+
+int compute_field_width(long nr_sinks) {
+    return (int) ceil(log(nr_sinks)/log(10));
 }

--- a/src/info_sink.c
+++ b/src/info_sink.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[]) {
     Meta_data meta_data;
     FILE *fp;
     long id, data_size, nr_unused = 0, nr_overrun = 0;
-    int field_width;
+    int id_field_width, byte_field_width;
     initCL(&params);
     parseCL(&params, &argc, &argv);
     if (params.verbose) {
@@ -26,11 +26,13 @@ int main(int argc, char *argv[]) {
     printf("meta size = %ld byte\n", meta_data.meta_size);
     printf("sink size = %ld byte\n", meta_data.sink_size);
     printf("number of sinks = %ld\n", meta_data.nr_sinks);
-    field_width = compute_field_width(meta_data.nr_sinks);
+    id_field_width = compute_field_width(meta_data.nr_sinks);
+    byte_field_width = compute_field_width(meta_data.sink_size);
     for (id = 0; id < meta_data.nr_sinks; id++) {
         data_size = read_data_size(fp, id);
         if (data_size >= 0) {
-            printf("size id %5ld = %ld byte", id, data_size);
+            printf("size id %*ld = %*ld byte", id_field_width, id,
+                    byte_field_width, data_size);
             if (data_size > meta_data.sink_size) {
                 nr_overrun++;
                 printf(" > %ld, %ld byte lost", meta_data.sink_size,
@@ -38,7 +40,7 @@ int main(int argc, char *argv[]) {
             }
             printf("\n");
         } else {
-            printf("size id %5ld unused\n", id);
+            printf("size id %*ld unused\n", id_field_width, id);
             nr_unused++;
         }
     }

--- a/src/split_sink.c
+++ b/src/split_sink.c
@@ -32,6 +32,10 @@ int main(int argc, char *argv[]) {
             warnx("no data was written for id %ld\n", id);
             continue;
         }
+        if (data_size > meta_data.sink_size) {
+            warnx("%ld byte written to sink %ld, capacity exceede by %ld byte", data_size, id, data_size - meta_data.sink_size);
+            data_size = meta_data.sink_size;
+        }
         seek_data(ifp, &meta_data, id);
         if ((file_name = (char *) malloc(sizeof(char)*name_len)) == NULL) {
             errx(EXIT_MEM_ERR, "can allocate file name");

--- a/src/vacuum_sink.c
+++ b/src/vacuum_sink.c
@@ -30,6 +30,10 @@ int main(int argc, char *argv[]) {
     }
     for (id = 0; id < meta_data.nr_sinks; id++) {
         data_size = read_data_size(ifp, id);
+        if (data_size > meta_data.sink_size) {
+            warnx("%ld byte written to sink %ld, capacity exceede by %ld byte", data_size, id, data_size - meta_data.sink_size);
+            data_size = meta_data.sink_size;
+        }
         if (data_size < 0) {
             warnx("no data was written for id %ld\n", id);
             continue;


### PR DESCRIPTION
Adds warnings on sink overruns for info_sink, vacuum_sink, split_sink.  vacuum_sink and split_sink will now also generate correct output in case of sink overrun.  Output formatting of info_sink has been improved. Fixes #2 
